### PR TITLE
shellHook: use exec

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,5 @@
 pkgs.mkShell {
   name = "nixos-up";
   buildInputs = with pkgs; [ ocaml jq ];
-  shellHook = ''
-    ocaml ${./nixos-up.ml}
-    exit $?
-  '';
+  shellHook = "exec ocaml ${./nixos-up.ml}";
 }


### PR DESCRIPTION
Using exec looks simpler and is probably cleaner