### PR TITLE
/dev/mmc[...] drives

### DIFF
--- a/nixos-up.py
+++ b/nixos-up.py
@@ -141,7 +141,6 @@ else:
 ### Formatting
 # Different linux device drivers have different partition naming conventions.
 def partition_name(disk: str, partition: int) -> str:
-  print(f"{disk}p{partition}");
   if disk.startswith("sd"):
     return f"{disk}{partition}"
   elif disk.startswith("nvme"):

--- a/nixos-up.py
+++ b/nixos-up.py
@@ -145,7 +145,7 @@ def partition_name(disk: str, partition: int) -> str:
     return f"{disk}{partition}"
   elif disk.startswith("nvme"):
     return f"{disk}p{partition}"
-  elif disk.startswith("blk"):
+  elif disk.startswith("mmc"):
     return f"{disk}p{partition}"
   else:
     print("Warning: this type of device driver has not been thoroughly tested with nixos-up, and its partition naming scheme may differ from what we expect. Please open an issue at https://github.com/samuela/nixos-up/issues.")

--- a/nixos-up.py
+++ b/nixos-up.py
@@ -145,6 +145,8 @@ def partition_name(disk: str, partition: int) -> str:
     return f"{disk}{partition}"
   elif disk.startswith("nvme"):
     return f"{disk}p{partition}"
+  elif disk.startswith("blk"):
+    return f"{disk}p{partition}"
   else:
     print("Warning: this type of device driver has not been thoroughly tested with nixos-up, and its partition naming scheme may differ from what we expect. Please open an issue at https://github.com/samuela/nixos-up/issues.")
     return f"{disk}{partition}"

--- a/nixos-up.py
+++ b/nixos-up.py
@@ -141,6 +141,7 @@ else:
 ### Formatting
 # Different linux device drivers have different partition naming conventions.
 def partition_name(disk: str, partition: int) -> str:
+  print(f"{disk}p{partition}");
   if disk.startswith("sd"):
     return f"{disk}{partition}"
   elif disk.startswith("nvme"):


### PR DESCRIPTION
I've just installed NixOS onto a (rather old) ASUS tablet laptop (to gain some familiarity with the OS).  The main drive is `/dev/mmcblk2` and partitions into `/dev/mmcblk2p1` and `/dev/mmcblk2p2`.  So this PR just reflects that.

No pressure to accept it, just wanted to possibly fix the issue for a future person :)